### PR TITLE
Initial version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+    day: sunday
+    time: "11:00"
+    timezone: Europe/Berlin

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,20 @@
+name: Validate
+
+on: push
+
+env:
+  AWS_REGION: local
+
+jobs:
+  validate:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: _test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hashicorp/setup-terraform@v1.3.2
+        with:
+          terraform_version: 0.15.5
+      - run: terraform init
+      - run: terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/_test/.terraform
+/_test/.terraform.lock.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0.0
+
+- [Initial version](https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/1)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2022 Babbel GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # terraform-aws-cloudfront-bucket
 
 This modules creates an S3 bucket with a CloudFront distribution in front.
+The integration between CloudFront and the S3 bucket is protected,
+and the bucket is set up to be not directly accessible, only via the CDN.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # terraform-aws-cloudfront-bucket
-Terraform module creating an S3 bucket with a CloudFront distribution in front
+
+This modules creates an S3 bucket with a CloudFront distribution in front.
+
+## Example
+
+```tf
+module "cloudfront-bucket-example" {
+  source  = "babbel/cloudfront-bucket/aws"
+  version = "~> 1.0"
+
+  bucket_name = "foo"
+
+  tags = {
+    environment = "production"
+  }
+}
+```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -1,13 +1,13 @@
 module "s3-bucket-with-cloudfront" {
   source = "./.."
 
-  bucket_name = ""
+  bucket_name = "example-with-default-cert"
 }
 
 module "s3-bucket-with-cloudfront-with-custom-cert" {
   source = "./.."
 
-  bucket_name = ""
+  bucket_name = "example-with-custom-cert"
 
   acm_certificate = {
     arn = "arn:aws:acm:eu-west-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -1,0 +1,5 @@
+module "s3-bucket-with-cloudfront" {
+  source = "./.."
+
+  bucket_name = ""
+}

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -3,3 +3,13 @@ module "s3-bucket-with-cloudfront" {
 
   bucket_name = ""
 }
+
+module "s3-bucket-with-cloudfront-with-custom-cert" {
+  source = "./.."
+
+  bucket_name = ""
+
+  acm_certificate = {
+    arn = "arn:aws:acm:eu-west-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+  }
+}

--- a/_test/versions.tf
+++ b/_test/versions.tf
@@ -1,0 +1,1 @@
+../versions.tf

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,0 +1,58 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+
+    principals {
+      type        = "CanonicalUser"
+      identifiers = [aws_cloudfront_origin_access_identity.this.s3_canonical_user_id]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.bucket
+  policy = data.aws_iam_policy_document.bucket_policy.json
+
+  lifecycle {
+    ignore_changes = [
+      # When setting a "CanonicalUser" in an S3 bucket policy,
+      # S3 changes the policy into something like
+      # "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ...",
+      # sometimes with spaces and sometimes with underscores as separators after
+      # "user/".
+      #
+      # We also cannot set that IAM user directly, because we cannot know whether
+      # a bucket accepts an IAM user with spaces or with underscores.
+      #
+      # https://github.com/terraform-providers/terraform-provider-aws/issues/10158
+      #
+      # However, we can always set the documented way using "CanonicalUser",
+      # even if S3 changes value into the IAM user later on.
+      #
+      # We just need to ignore changes on the policy when refreshing
+      # the Terraform state from the S3 API.
+      #
+      policy,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "fullaccess" {
+  statement {
+    actions   = ["s3:List*", "s3:Get*"]
+    resources = [aws_s3_bucket.this.arn]
+  }
+
+  statement {
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+  }
+}

--- a/bucket.tf
+++ b/bucket.tf
@@ -44,15 +44,3 @@ resource "aws_s3_bucket_policy" "this" {
     ]
   }
 }
-
-data "aws_iam_policy_document" "fullaccess" {
-  statement {
-    actions   = ["s3:List*", "s3:Get*"]
-    resources = [aws_s3_bucket.this.arn]
-  }
-
-  statement {
-    actions   = ["s3:*"]
-    resources = ["${aws_s3_bucket.this.arn}/*"]
-  }
-}

--- a/bucket.tf
+++ b/bucket.tf
@@ -20,27 +20,4 @@ data "aws_iam_policy_document" "bucket_policy" {
 resource "aws_s3_bucket_policy" "this" {
   bucket = aws_s3_bucket.this.bucket
   policy = data.aws_iam_policy_document.bucket_policy.json
-
-  lifecycle {
-    ignore_changes = [
-      # When setting a "CanonicalUser" in an S3 bucket policy,
-      # S3 changes the policy into something like
-      # "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ...",
-      # sometimes with spaces and sometimes with underscores as separators after
-      # "user/".
-      #
-      # We also cannot set that IAM user directly, because we cannot know whether
-      # a bucket accepts an IAM user with spaces or with underscores.
-      #
-      # https://github.com/terraform-providers/terraform-provider-aws/issues/10158
-      #
-      # However, we can always set the documented way using "CanonicalUser",
-      # even if S3 changes value into the IAM user later on.
-      #
-      # We just need to ignore changes on the policy when refreshing
-      # the Terraform state from the S3 API.
-      #
-      policy,
-    ]
-  }
 }

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -82,7 +82,7 @@ locals {
   acm_viewer_certificate = {
     acm_certificate_arn            = try(var.acm_certificate.arn, null)
     cloudfront_default_certificate = false
-    minimum_protocol_version       = "TLSv1"
+    minimum_protocol_version       = var.acm_certificate_minimum_protocol_version
     ssl_support_method             = "sni-only"
   }
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,0 +1,90 @@
+resource "aws_cloudfront_distribution" "this" {
+  comment = aws_s3_bucket.this.bucket
+  enabled = true
+
+  aliases = var.aliases
+
+  http_version = "http2"
+
+  origin {
+    origin_id   = "S3-${aws_s3_bucket.this.bucket}"
+    domain_name = aws_s3_bucket.this.bucket_domain_name
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "S3-${aws_s3_bucket.this.bucket}"
+    viewer_protocol_policy = "https-only"
+
+    allowed_methods = [
+      "GET",
+      "HEAD",
+    ]
+
+    cached_methods = [
+      "GET",
+      "HEAD",
+    ]
+
+    forwarded_values {
+      query_string = false
+
+      headers = [
+        "Access-Control-Request-Headers",
+        "Access-Control-Request-Method",
+        "Origin",
+      ]
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl     = var.ttl.min
+    default_ttl = var.ttl.default
+    max_ttl     = var.ttl.max
+
+    compress = true
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = local.viewer_certificate.acm_certificate_arn
+    cloudfront_default_certificate = local.viewer_certificate.cloudfront_default_certificate
+
+    minimum_protocol_version = local.viewer_certificate.minimum_protocol_version
+    ssl_support_method       = local.viewer_certificate.ssl_support_method
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudfront_origin_access_identity" "this" {
+  comment = aws_s3_bucket.this.bucket
+}
+
+locals {
+  default_viewer_certificate = {
+    acm_certificate_arn            = null
+    cloudfront_default_certificate = true
+    minimum_protocol_version       = "TLSv1"
+    ssl_support_method             = null
+  }
+
+  acm_viewer_certificate = {
+    acm_certificate_arn            = var.acm_certificate_arn
+    cloudfront_default_certificate = false
+    minimum_protocol_version       = "TLSv1"
+    ssl_support_method             = "sni-only"
+  }
+
+  viewer_certificate = var.acm_certificate_arn != null ? local.acm_viewer_certificate : local.default_viewer_certificate
+}

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -80,11 +80,11 @@ locals {
   }
 
   acm_viewer_certificate = {
-    acm_certificate_arn            = var.acm_certificate_arn
+    acm_certificate_arn            = try(var.acm_certificate.arn, null)
     cloudfront_default_certificate = false
     minimum_protocol_version       = "TLSv1"
     ssl_support_method             = "sni-only"
   }
 
-  viewer_certificate = var.acm_certificate_arn != null ? local.acm_viewer_certificate : local.default_viewer_certificate
+  viewer_certificate = var.acm_certificate != null ? local.acm_viewer_certificate : local.default_viewer_certificate
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,17 @@
+output "bucket" {
+  value = aws_s3_bucket.this
+
+  description = "The created bucket"
+}
+
+output "bucket_fullaccess_policy_document" {
+  value = data.aws_iam_policy_document.fullaccess.json
+
+  description = "IAM policy document granting full access to the created bucket"
+}
+
+output "cloudfront_distribution" {
+  value = aws_cloudfront_distribution.this
+
+  description = "The CloudFront distribution connected with the created bucket"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,12 +4,6 @@ output "bucket" {
   description = "The created bucket"
 }
 
-output "bucket_fullaccess_policy_document" {
-  value = data.aws_iam_policy_document.fullaccess.json
-
-  description = "IAM policy document granting full access to the created bucket"
-}
-
 output "cloudfront_distribution" {
   value = aws_cloudfront_distribution.this
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,52 @@
+variable "acm_certificate_arn" {
+  type    = string
+  default = null
+
+  description = <<EOS
+The ARN of the ACM certificate that you want to use with the CloudFront distribution.
+If not specified, the default CloudFront certificate for *.cloudfront.net will be used.
+
+This only makes sense in combination with `aliases`.
+EOS
+}
+
+variable "aliases" {
+  type    = list(string)
+  default = null
+
+  description = <<EOS
+List of custom domain which shall be served by the CloudFront distribution.
+
+In order to serve the content via HTTPS, you need to specify an ACM certificate
+with matchgin domains via `acm_certificate_arn`.
+EOS
+}
+
+variable "bucket_name" {
+  type = string
+
+  description = "Name of the S3 bucket to create"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {} # Use structural Object Type in Terraform 0.12
+
+  description = "Tags to be assigned to the S3 bucket and the CloudFront distribution"
+}
+
+variable "ttl" {
+  type = object({
+    min     = number
+    default = number
+    max     = number
+  })
+
+  default = {
+    min     = 0
+    default = 86400
+    max     = 31536000
+  }
+
+  description = "The min, default and max TTLs set on the CloudFront distribution"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ EOS
 
 variable "acm_certificate_minimum_protocol_version" {
   type    = string
-  default = "TLSv1"
+  default = "TLSv1.3"
 
   description = <<EOS
 The minimum protocol version for the ACM viewer certificate that you want to use with
@@ -22,7 +22,7 @@ the CloudFront distribution.
 Supported protocols and ciphers are documented here:
 https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
 
-If not specified, it defaults to `"TLSv1"`.
+If not specified, it defaults to `"TLSv1.3"`.
 EOS
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,7 @@
-variable "acm_certificate_arn" {
-  type    = string
+variable "acm_certificate" {
+  type    = object({
+    arn = string
+  })
   default = null
 
   description = <<EOS

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,20 @@ This only makes sense in combination with `aliases`.
 EOS
 }
 
+variable "acm_certificate_minimum_protocol_version" {
+  type    = string
+  default = "TLSv1"
+
+  description = <<EOS
+The minimum protocol version for the ACM viewer certificate that you want to use with
+the CloudFront distribution.
+Supported protocols and ciphers are documented here:
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
+
+If not specified, it defaults to `"TLSv1"`.
+EOS
+}
+
 variable "aliases" {
   type    = list(string)
   default = null

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "bucket_name" {
 
 variable "tags" {
   type    = map(string)
-  default = {} # Use structural Object Type in Terraform 0.12
+  default = {}
 
   description = "Tags to be assigned to the S3 bucket and the CloudFront distribution"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This is extracting the module we're currently using. The interface is slimmed down, consumers of this modules are expected to add the following S3 resources:

- `aws_s3_bucket_acl`
- `aws_s3_bucket_public_access_block`
- `aws_s3_bucket_cors_configuration`
- `aws_s3_bucket_versioning`
- `aws_s3_bucket_server_side_encryption_configuration`
- `aws_s3_bucket_lifecycle_configuration`

We *could* consider creating the `aws_s3_bucket_cors_configuration` here in the module, there is no config for it, it's always created and always with the same attributes.

Let me know what you think!