### PR TITLE
Use correct identifier for TLS 1.3

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ EOS
 
 variable "acm_certificate_minimum_protocol_version" {
   type    = string
-  default = "TLSv1.3"
+  default = "TLSv1.2_2021"
 
   description = <<EOS
 The minimum protocol version for the ACM viewer certificate that you want to use with
@@ -22,7 +22,7 @@ the CloudFront distribution.
 Supported protocols and ciphers are documented here:
 https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html
 
-If not specified, it defaults to `"TLSv1.3"`.
+If not specified, it defaults to `"TLSv1.2_2021"`.
 EOS
 }
 


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html, the values listed in "Security policy" are possible values.

This will be released as 1.0.1