### PR TITLE
Prefer IAM ARN over CanonicalUser for S3 bucket policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+
+- [Prefer IAM ARN over CanonicalUser for S3 bucket policy](https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/5)
+
 ## v1.0.1
 
 - [Use correct identifier for TLS 1.3](https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/3)

--- a/bucket.tf
+++ b/bucket.tf
@@ -8,8 +8,8 @@ data "aws_iam_policy_document" "bucket_policy" {
   statement {
 
     principals {
-      type        = "CanonicalUser"
-      identifiers = [aws_cloudfront_origin_access_identity.this.s3_canonical_user_id]
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.this.iam_arn]
     }
 
     actions   = ["s3:GetObject"]


### PR DESCRIPTION
Deploying this with `"CanonicalUser` produces the same recurring diff we have seen before. Let's use the IAM ARN from the same `aws_cloudfront_origin_access_identity` resource instead to get rid of this problem and release this as **v1.1.0**.

- [x] Changes are documented
