### PR TITLE
Switch back to CanonicalUser, ignoring any policy changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.0
+
+- [Switch back to CanonicalUser, ignoring any policy changes](https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/6)
+
 ## v1.1.0
 
 - [Prefer IAM ARN over CanonicalUser for S3 bucket policy](https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/5)

--- a/bucket.tf
+++ b/bucket.tf
@@ -8,8 +8,8 @@ data "aws_iam_policy_document" "bucket_policy" {
   statement {
 
     principals {
-      type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.this.iam_arn]
+      type        = "CanonicalUser"
+      identifiers = [aws_cloudfront_origin_access_identity.this.s3_canonical_user_id]
     }
 
     actions   = ["s3:GetObject"]
@@ -20,4 +20,27 @@ data "aws_iam_policy_document" "bucket_policy" {
 resource "aws_s3_bucket_policy" "this" {
   bucket = aws_s3_bucket.this.bucket
   policy = data.aws_iam_policy_document.bucket_policy.json
+
+  lifecycle {
+    ignore_changes = [
+      # When setting a "CanonicalUser" in an S3 bucket policy,
+      # S3 changes the policy into something like
+      # "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ...",
+      # sometimes with spaces and sometimes with underscores as separators after
+      # "user/".
+      #
+      # We also cannot set that IAM user directly, because we cannot know whether
+      # a bucket accepts an IAM user with spaces or with underscores.
+      #
+      # https://github.com/terraform-providers/terraform-provider-aws/issues/10158
+      #
+      # However, we can always set the documented way using "CanonicalUser",
+      # even if S3 changes value into the IAM user later on.
+      #
+      # We just need to ignore changes on the policy when refreshing
+      # the Terraform state from the S3 API.
+      #
+      policy,
+    ]
+  }
 }


### PR DESCRIPTION
It turns the issue with principal `CanonicalUser` vs. `AWS` is still not fixed, see https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/1#discussion_r835141420 and https://github.com/hashicorp/terraform-provider-aws/issues/10158#issuecomment-1102714009.

- [x] changes are documented