### PR TITLE
Relax version constraints for modules

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,10 @@
 terraform {
+  required_version = ">= 0.13"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0"
     }
   }
-  required_version = ">= 0.13"
 }


### PR DESCRIPTION
Remove upper boundary as version upgrades need to be tested when applying the root modules anyway.