### PR TITLE
Add optional var trusted_key_groups

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -19,7 +19,7 @@ resource "aws_cloudfront_distribution" "this" {
     target_origin_id       = "S3-${aws_s3_bucket.this.bucket}"
     viewer_protocol_policy = "https-only"
 
-    trusted_key_groups = var.trusted_key_groups
+    trusted_key_groups = var.trusted_key_groups == null ? null : var.trusted_key_groups[*].id
 
     allowed_methods = [
       "GET",

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -19,6 +19,8 @@ resource "aws_cloudfront_distribution" "this" {
     target_origin_id       = "S3-${aws_s3_bucket.this.bucket}"
     viewer_protocol_policy = "https-only"
 
+    trusted_key_groups = var.trusted_key_groups
+
     allowed_methods = [
       "GET",
       "HEAD",

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,12 @@ variable "tags" {
 
 
 variable "trusted_key_groups" {
-  type    = list(string)
+  type = list(
+    object({
+      id = string
+    })
+  )
+
   default = null
 
   description = "List of AWS Key Groups to trust for CloudFront distribution's default cache behavior"

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,14 @@ variable "tags" {
   description = "Tags to be assigned to the S3 bucket and the CloudFront distribution"
 }
 
+
+variable "trusted_key_groups" {
+  type    = list(string)
+  default = null
+
+  description = "List of AWS Key Groups to trust for CloudFront distribution's default cache behavior"
+}
+
 variable "ttl" {
   type = object({
     min     = number


### PR DESCRIPTION
Cf. [AWS' documentation of feature](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#trusted_key_groups).

# Depends on
- [x] https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/23