### PR TITLE
Fix dynamic custom_error_response

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -70,10 +70,10 @@ resource "aws_cloudfront_distribution" "this" {
     for_each = var.custom_error_response
 
     content {
-      error_caching_min_ttl = custom_error_response.error_caching_min_ttl
-      error_code            = custom_error_response.error_code
-      response_code         = custom_error_response.response_code
-      response_page_path    = custom_error_response.response_page_path
+      error_caching_min_ttl = custom_error_response.value.error_caching_min_ttl
+      error_code            = custom_error_response.value.error_code
+      response_code         = custom_error_response.value.response_code
+      response_page_path    = custom_error_response.value.response_page_path
     }
   }
 


### PR DESCRIPTION
Fixing the setup of the dynamic attribute `custom_error_response` introduced in https://github.com/babbel/terraform-aws-cloudfront-bucket/pull/25