### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,5 @@ module "cloudfront-bucket-example" {
   version = "~> 1.0"
 
   bucket_name = "foo"
-
-  tags = {
-    environment = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -5,13 +5,13 @@ provider "aws" {
 module "s3-bucket-with-cloudfront" {
   source = "./.."
 
-  bucket_name = "example-with-default-cert"
+  s3_bucket_name = "example-with-default-cert"
 }
 
 module "s3-bucket-with-cloudfront-with-custom-cert" {
   source = "./.."
 
-  bucket_name = "example-with-custom-cert"
+  s3_bucket_name = "example-with-custom-cert"
 
   acm_certificate = {
     arn = "arn:aws:acm:eu-west-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "this" {
-  bucket = var.bucket_name
+  bucket = var.s3_bucket_name
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.s3_bucket_tags)
 }
 
 data "aws_iam_policy_document" "bucket_policy" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
-  tags = var.tags
+  tags = marge(var.default_tags, var.cloudfront_distribution_tags)
 }
 
 locals {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
-  tags = marge(var.default_tags, var.cloudfront_distribution_tags)
+  tags = merge(var.default_tags, var.cloudfront_distribution_tags)
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -38,10 +38,13 @@ with matchgin domains via `acm_certificate_arn`.
 EOS
 }
 
-variable "bucket_name" {
-  type = string
+variable "cloudfront_distribution_tags" {
+  type    = map(string)
+  default = {}
 
-  description = "Name of the S3 bucket to create"
+  description = <<EOS
+Map of tags assigned to the CloudFront distribution.
+EOS
 }
 
 variable "custom_error_response" {
@@ -53,33 +56,56 @@ variable "custom_error_response" {
       response_page_path    = string
     })
   )
-
   default = []
 
-  description = "One or more custom error response elements to be used for the CloudFront distribution"
+  description = <<EOS
+One or more custom error response elements to be used for the CloudFront distribution.
+EOS
 }
 
 variable "default_root_object" {
   type    = string
   default = null
 
-  description = "The default root object CloudFront is to request from the S3 bucket as root URL"
+  description = <<EOS
+The default root object CloudFront is to request from the S3 bucket as root URL.
+EOS
+}
+
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
 }
 
 variable "http_version" {
   type    = string
   default = "http2"
 
-  description = "Supported HTTP versions set on the CloudFront distribution"
+  description = <<EOS
+Supported HTTP versions set on the CloudFront distribution".
+EOS
 }
 
-variable "tags" {
+variable "s3_bucket_name" {
+  type = string
+
+  description = <<EOS
+Name of the S3 bucket to create.
+EOS
+}
+
+variable "s3_bucket_tags" {
   type    = map(string)
   default = {}
 
-  description = "Tags to be assigned to the S3 bucket and the CloudFront distribution"
+  description = <<EOS
+Map of tags assigned to the S3 bucket.
+EOS
 }
-
 
 variable "trusted_key_groups" {
   type = list(
@@ -87,10 +113,11 @@ variable "trusted_key_groups" {
       id = string
     })
   )
-
   default = null
 
-  description = "List of AWS Key Groups to trust for CloudFront distribution's default cache behavior"
+  description = <<EOS
+List of AWS Key Groups to trust for CloudFront distribution's default cache behavior.
+EOS
 }
 
 variable "ttl" {
@@ -99,12 +126,13 @@ variable "ttl" {
     default = number
     max     = number
   })
-
   default = {
     min     = 0
     default = 86400
     max     = 31536000
   }
 
-  description = "The min, default and max TTLs set on the CloudFront distribution"
+  description = <<EOS
+The min, default and max TTLs set on the CloudFront distribution.
+EOS
 }


### PR DESCRIPTION
Breaking changes:

* Renaming `var.bucket_name` to `var.s3_bucket_name` for symmetry with `var.s3_bucket_tags`.
* Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.