### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,5 @@ module "cloudfront-bucket-example" {
   version = "~> 1.0"
 
   bucket_name = "foo"
-
-  tags = {
-    environment = "production"
-  }
 }
 ```

--- a/bucket.tf
+++ b/bucket.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket" "this" {
   bucket = var.bucket_name
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 data "aws_iam_policy_document" "bucket_policy" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "this" {
     }
   }
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -71,16 +71,7 @@ The default root object CloudFront is to request from the S3 bucket as root URL.
 EOS
 }
 
-variable "http_version" {
-  type    = string
-  default = "http2"
-
-  description = <<EOS
-Supported HTTP versions set on the CloudFront distribution.
-EOS
-}
-
-variable "tags" {
+variable "default_tags" {
   type    = map(string)
   default = {}
 
@@ -89,6 +80,14 @@ Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 
+variable "http_version" {
+  type    = string
+  default = "http2"
+
+  description = <<EOS
+Supported HTTP versions set on the CloudFront distribution.
+EOS
+}
 
 variable "trusted_key_groups" {
   type = list(


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.